### PR TITLE
Use microLamports for setComputeUnitPrice

### DIFF
--- a/clients/js/src/generated/instructions/setComputeUnitPrice.ts
+++ b/clients/js/src/generated/instructions/setComputeUnitPrice.ts
@@ -8,9 +8,7 @@
 
 import {
   Context,
-  SolAmount,
   TransactionBuilder,
-  mapAmountSerializer,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
 import {
@@ -30,12 +28,12 @@ import {
 export type SetComputeUnitPriceInstructionData = {
   discriminator: number;
   /** Transaction compute unit price used for prioritization fees. */
-  lamports: SolAmount;
+  microLamports: bigint;
 };
 
 export type SetComputeUnitPriceInstructionDataArgs = {
   /** Transaction compute unit price used for prioritization fees. */
-  lamports: SolAmount;
+  microLamports: number | bigint;
 };
 
 export function getSetComputeUnitPriceInstructionDataSerializer(): Serializer<
@@ -50,7 +48,7 @@ export function getSetComputeUnitPriceInstructionDataSerializer(): Serializer<
     struct<SetComputeUnitPriceInstructionData>(
       [
         ['discriminator', u8()],
-        ['lamports', mapAmountSerializer(u64(), 'SOL', 9)],
+        ['microLamports', u64()],
       ],
       { description: 'SetComputeUnitPriceInstructionData' }
     ),

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -136,7 +136,6 @@ kinobi.update(
   new k.SetNumberWrappersVisitor({
     "splSystem.CreateAccount.lamports": { kind: "SolAmount" },
     "splSystem.TransferSol.amount": { kind: "SolAmount" },
-    "splComputeBudget.SetComputeUnitPrice.lamports": { kind: "SolAmount" },
   })
 );
 

--- a/idls/spl_compute_budget.json
+++ b/idls/spl_compute_budget.json
@@ -52,7 +52,7 @@
       "discriminant": { "value": 3, "type": "u8" },
       "args": [
         {
-          "name": "lamports",
+          "name": "microLamports",
           "type": "u64",
           "docs": [
             "Transaction compute unit price used for prioritization fees."


### PR DESCRIPTION
Fix misuse of the `lamports` argument for the `setComputeUnitPrice` instruction. The program does not expect lamports but micro-lamports. As such, this PR renames the argument to `microLamports` and removes the `SolAmount` mapping.