### PR TITLE
fix: manually fix createidempotentAssociatedToken data serialization

### DIFF
--- a/clients/js/src/generated/instructions/createIdempotentAssociatedToken.ts
+++ b/clients/js/src/generated/instructions/createIdempotentAssociatedToken.ts
@@ -15,6 +15,12 @@ import {
   transactionBuilder,
 } from '@metaplex-foundation/umi';
 import {
+  Serializer,
+  mapSerializer,
+  struct,
+  u8,
+} from '@metaplex-foundation/umi/serializers';
+import {
   ResolvedAccount,
   ResolvedAccountsWithIndices,
   getAccountMetasAndSigners,
@@ -30,6 +36,33 @@ export type CreateIdempotentAssociatedTokenInstructionAccounts = {
   tokenProgram?: PublicKey | Pda;
 };
 
+// Data.
+export type CreateIdempotentAssociatedTokenInstructionData = {
+  discriminator: number;
+};
+export type CreateIdempotentAssociatedTokenInstructionDataArgs = {};
+
+export function getCreateIdempotentAssociatedTokenInstructionDataSerializer(): Serializer<
+  CreateIdempotentAssociatedTokenInstructionDataArgs,
+  CreateIdempotentAssociatedTokenInstructionData
+> {
+  return mapSerializer<
+    CreateIdempotentAssociatedTokenInstructionDataArgs,
+    any,
+    CreateIdempotentAssociatedTokenInstructionData
+  >(
+    struct<CreateIdempotentAssociatedTokenInstructionData>(
+      [['discriminator', u8()]],
+      {
+        description: 'CreateIdempotentAssociatedTokenInstructionData',
+      }
+    ),
+    (value) => ({ ...value, discriminator: 1 })
+  ) as Serializer<
+    CreateIdempotentAssociatedTokenInstructionDataArgs,
+    CreateIdempotentAssociatedTokenInstructionData
+  >;
+}
 // Instruction.
 export function createIdempotentAssociatedToken(
   context: Pick<Context, 'payer' | 'programs'>,
@@ -91,7 +124,8 @@ export function createIdempotentAssociatedToken(
   );
 
   // Data.
-  const data = new Uint8Array();
+  const data =
+    getCreateIdempotentAssociatedTokenInstructionDataSerializer().serialize({});
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;


### PR DESCRIPTION
Manually fixes the data serialization for createAssociatedTokenIdempotent

prior to this fix, the instruction is processed as the  plain `createAssociatedTokenAccount` since the data is empty (https://github.com/solana-program/associated-token-account/blob/0b867b5340cd001e5980d8ca7928effc4e10015c/program/src/processor.rs#L42) and if you pass in an ATA account that's already initialized(or any account not owned by the system program), the transaction will fail. 
https://github.com/solana-program/associated-token-account/blob/program%40v8.0.0/program/src/processor.rs#L107-L109

I ran the `pnpm generate:client` and it didn't update anything. Didn't have time to look into kinobi (dont know if it's even still actively maintained) to see where the root cause was from that side.